### PR TITLE
delete metric_writer.write_{pointcloud,summaries}

### DIFF
--- a/src/jax_loop_utils/metric_writers/async_writer.py
+++ b/src/jax_loop_utils/metric_writers/async_writer.py
@@ -75,17 +75,6 @@ class AsyncWriter(interface.MetricWriter):
             thread_name_prefix="AsyncWriter", max_workers=num_workers
         )
 
-    @_wrap_exceptions  # type: ignore[call-arg]  # type: ignore[call-arg]
-    def write_summaries(
-        self,
-        step: int,
-        values: Mapping[str, Array],
-        metadata: Optional[Mapping[str, Any]] = None,
-    ):
-        self._pool(self._writer.write_summaries)(
-            step=step, values=values, metadata=metadata
-        )
-
     @_wrap_exceptions  # type: ignore[call-arg]
     def write_scalars(self, step: int, scalars: Mapping[str, Scalar]):
         self._pool(self._writer.write_scalars)(step=step, scalars=scalars)
@@ -117,22 +106,6 @@ class AsyncWriter(interface.MetricWriter):
     ):
         self._pool(self._writer.write_histograms)(
             step=step, arrays=arrays, num_buckets=num_buckets
-        )
-
-    @_wrap_exceptions  # type: ignore[call-arg]
-    def write_pointcloud(
-        self,
-        step: int,
-        point_clouds: Mapping[str, Array],
-        *,
-        point_colors: Mapping[str, Array] | None = None,
-        configs: Mapping[str, str | float | bool | None] | None = None,
-    ):
-        self._pool(self._writer.write_pointcloud)(
-            step=step,
-            point_clouds=point_clouds,
-            point_colors=point_colors,
-            configs=configs,
         )
 
     @_wrap_exceptions  # type: ignore[call-arg]

--- a/src/jax_loop_utils/metric_writers/async_writer_test.py
+++ b/src/jax_loop_utils/metric_writers/async_writer_test.py
@@ -30,17 +30,6 @@ class AsyncWriterTest(absltest.TestCase):
         self.sync_writer = mock.create_autospec(interface.MetricWriter)
         self.writer = async_writer.AsyncWriter(self.sync_writer)
 
-    def test_write_summaries_async(self):
-        self.writer.write_summaries(
-            11,
-            {"a": np.eye(3, dtype=np.uint8), "b": np.eye(2, dtype=np.float32)},
-            {"a": np.ones((2, 3)).tobytes()},
-        )
-        self.writer.flush()
-        self.sync_writer.write_summaries.assert_called_with(
-            step=11, values={"a": mock.ANY, "b": mock.ANY}, metadata={"a": mock.ANY}
-        )
-
     def test_write_scalars_async(self):
         self.writer.write_scalars(0, {"a": 3, "b": 0.15})
         self.writer.write_scalars(2, {"a": 5, "b": 0.007})
@@ -63,27 +52,6 @@ class AsyncWriterTest(absltest.TestCase):
         self.writer.write_videos(4, {"input_videos": videos})
         self.writer.flush()
         self.sync_writer.write_videos.assert_called_with(4, {"input_videos": mock.ANY})
-
-    def test_write_pointcloud(self):
-        point_clouds = np.random.normal(0, 1, (1, 1024, 3)).astype(np.float32)
-        point_colors = np.random.uniform(0, 1, (1, 1024, 3)).astype(np.float32)
-        config = {
-            "material": "PointCloudMaterial",
-            "size": 0.09,
-        }
-        self.writer.write_pointcloud(
-            step=0,
-            point_clouds={"pcd": point_clouds},
-            point_colors={"pcd": point_colors},
-            configs=config,
-        )
-        self.writer.flush()
-        self.sync_writer.write_pointcloud.assert_called_with(
-            step=0,
-            point_clouds={"pcd": mock.ANY},
-            point_colors={"pcd": mock.ANY},
-            configs=config,
-        )
 
     def test_write_texts(self):
         self.writer.write_texts(4, {"samples": "bla"})

--- a/src/jax_loop_utils/metric_writers/interface.py
+++ b/src/jax_loop_utils/metric_writers/interface.py
@@ -34,24 +34,6 @@ class MetricWriter(abc.ABC):
     """MetricWriter inferface."""
 
     @abc.abstractmethod
-    def write_summaries(
-        self,
-        step: int,
-        values: Mapping[str, Array],
-        metadata: Optional[Mapping[str, Any]] = None,
-    ):
-        """Saves an arbitrary tensor summary.
-
-        Useful when working with custom plugins or constructing a summary directly.
-
-        Args:
-          step: Step at which the scalar values occurred.
-          values: Mapping from tensor keys to tensors.
-          metadata: Optional SummaryMetadata, as a proto or serialized bytes.
-                    Note that markdown formatting is rendered by tensorboard.
-        """
-
-    @abc.abstractmethod
     def write_scalars(self, step: int, scalars: Mapping[str, Scalar]):
         """Write scalar values for the step.
 
@@ -154,26 +136,6 @@ class MetricWriter(abc.ABC):
           num_buckets: Number of buckets used to create the histogram of the arrays.
             The default number of buckets depends on the particular implementation
             of the MetricWriter.
-        """
-
-    @abc.abstractmethod
-    def write_pointcloud(
-        self,
-        step: int,
-        point_clouds: Mapping[str, Array],
-        *,
-        point_colors: Mapping[str, Array] | None = None,
-        configs: Mapping[str, str | float | bool | None] | None = None,
-    ):
-        """Writes point cloud summaries.
-
-        Args:
-          step: Step at which the point cloud was generated.
-          point_clouds: Mapping from point clouds key to point cloud of shape [N, 3]
-            array of point coordinates.
-          point_colors: Mapping from point colors key to [N, 3] array of point
-            colors.
-          configs: A dictionary of configuration options for the point cloud.
         """
 
     @abc.abstractmethod

--- a/src/jax_loop_utils/metric_writers/logging_writer.py
+++ b/src/jax_loop_utils/metric_writers/logging_writer.py
@@ -35,19 +35,6 @@ class LoggingWriter(interface.MetricWriter):
         else:
             self._collection_str = ""
 
-    def write_summaries(
-        self,
-        step: int,
-        values: Mapping[str, Array],
-        metadata: Optional[Mapping[str, Any]] = None,
-    ):
-        logging.info(
-            "[%d]%s Got raw tensors: %s.",
-            step,
-            self._collection_str,
-            {k: v.shape for k, v in values.items()},
-        )
-
     def write_scalars(self, step: int, scalars: Mapping[str, Scalar]):
         values = [
             f"{k}={v:.6g}" if isinstance(v, float) else f"{k}={v}"
@@ -102,27 +89,6 @@ class LoggingWriter(interface.MetricWriter):
                     key,
                     _get_histogram_as_string(histo, bins),
                 )
-
-    def write_pointcloud(
-        self,
-        step: int,
-        point_clouds: Mapping[str, Array],
-        *,
-        point_colors: Mapping[str, Any] | None = None,
-        configs: Mapping[str, str | float | bool | None] | None = None,
-    ):
-        logging.info(
-            "[%d]%s Got point clouds: %s, point_colors: %s, configs: %s.",
-            step,
-            self._collection_str,
-            {k: v.shape for k, v in point_clouds.items()},
-            (
-                {k: v.shape for k, v in point_colors.items()}
-                if point_colors is not None
-                else None
-            ),
-            configs,
-        )
 
     def write_hparams(self, hparams: Mapping[str, Any]):
         logging.info("[Hyperparameters]%s %s", self._collection_str, hparams)

--- a/src/jax_loop_utils/metric_writers/logging_writer_test.py
+++ b/src/jax_loop_utils/metric_writers/logging_writer_test.py
@@ -81,29 +81,6 @@ class LoggingWriterTest(absltest.TestCase):
             ],
         )
 
-    def test_write_pointcloud(self):
-        point_clouds = np.random.normal(0, 1, (1, 1024, 3)).astype(np.float32)
-        point_colors = np.random.uniform(0, 1, (1, 1024, 3)).astype(np.float32)
-        config = {
-            "material": "PointCloudMaterial",
-            "size": 0.09,
-        }
-        with self.assertLogs(level="INFO") as logs:
-            self.writer.write_pointcloud(
-                step=4,
-                point_clouds={"pcd": point_clouds},
-                point_colors={"pcd": point_colors},
-                configs=config,
-            )
-        self.assertEqual(
-            logs.output,
-            [
-                "INFO:absl:[4] Got point clouds: {'pcd': (1, 1024, 3)},"
-                " point_colors: {'pcd': (1, 1024, 3)}, configs: {'material': "
-                "'PointCloudMaterial', 'size': 0.09}."
-            ],
-        )
-
     def test_write_hparams(self):
         with self.assertLogs(level="INFO") as logs:
             self.writer.write_hparams({"learning_rate": 0.1, "batch_size": 128})

--- a/src/jax_loop_utils/metric_writers/multi_writer.py
+++ b/src/jax_loop_utils/metric_writers/multi_writer.py
@@ -29,15 +29,6 @@ class MultiWriter(interface.MetricWriter):
     def __init__(self, writers: Sequence[interface.MetricWriter]):
         self._writers = tuple(writers)
 
-    def write_summaries(
-        self,
-        step: int,
-        values: Mapping[str, Array],
-        metadata: Optional[Mapping[str, Any]] = None,
-    ):
-        for w in self._writers:
-            w.write_summaries(step, values, metadata)
-
     def write_scalars(self, step: int, scalars: Mapping[str, Scalar]):
         for w in self._writers:
             w.write_scalars(step, scalars)
@@ -66,19 +57,6 @@ class MultiWriter(interface.MetricWriter):
     ):
         for w in self._writers:
             w.write_histograms(step, arrays, num_buckets)
-
-    def write_pointcloud(
-        self,
-        step: int,
-        point_clouds: Mapping[str, Array],
-        *,
-        point_colors: Mapping[str, Array] | None = None,
-        configs: Mapping[str, str | float | bool | None] | None = None,
-    ):
-        for w in self._writers:
-            w.write_pointcloud(
-                step, point_clouds, point_colors=point_colors, configs=configs
-            )
 
     def write_hparams(self, hparams: Mapping[str, Any]):
         for w in self._writers:

--- a/src/jax_loop_utils/metric_writers/multi_writer_test.py
+++ b/src/jax_loop_utils/metric_writers/multi_writer_test.py
@@ -16,7 +16,6 @@
 
 from unittest import mock
 
-import numpy as np
 from absl.testing import absltest
 
 from jax_loop_utils.metric_writers import interface, multi_writer
@@ -41,29 +40,6 @@ class MultiWriterTest(absltest.TestCase):
                     mock.call(step=0, scalars={"a": 3, "b": 0.15}),
                     mock.call(step=2, scalars={"a": 5, "b": 0.007}),
                 ]
-            )
-            w.flush.assert_called()
-
-    def test_write_pointcloud(self):
-        point_clouds = np.random.normal(0, 1, (1, 1024, 3)).astype(np.float32)
-        point_colors = np.random.uniform(0, 1, (1, 1024, 3)).astype(np.float32)
-        config = {
-            "material": "PointCloudMaterial",
-            "size": 0.09,
-        }
-        self.writer.write_pointcloud(
-            step=0,
-            point_clouds={"pcd": point_clouds},
-            point_colors={"pcd": point_colors},
-            configs=config,
-        )
-        self.writer.flush()
-        for w in self.writers:
-            w.write_pointcloud.assert_called_with(
-                step=0,
-                point_clouds={"pcd": point_clouds},
-                point_colors={"pcd": point_colors},
-                configs=config,
             )
             w.flush.assert_called()
 

--- a/src/jax_loop_utils/metric_writers/noop_writer.py
+++ b/src/jax_loop_utils/metric_writers/noop_writer.py
@@ -9,14 +9,6 @@ from jax_loop_utils.metric_writers.interface import Array, MetricWriter, Scalar
 class NoOpWriter(MetricWriter):
     """MetricWriter that performs no operations."""
 
-    def write_summaries(
-        self,
-        step: int,
-        values: Mapping[str, Array],
-        metadata: Optional[Mapping[str, Any]] = None,
-    ):
-        pass
-
     def write_scalars(self, step: int, scalars: Mapping[str, Scalar]):
         pass
 
@@ -37,16 +29,6 @@ class NoOpWriter(MetricWriter):
         step: int,
         arrays: Mapping[str, Array],
         num_buckets: Optional[Mapping[str, int]] = None,
-    ):
-        pass
-
-    def write_pointcloud(
-        self,
-        step: int,
-        point_clouds: Mapping[str, Array],
-        *,
-        point_colors: Mapping[str, Array] | None = None,
-        configs: Mapping[str, str | float | bool | None] | None = None,
     ):
         pass
 

--- a/src/jax_loop_utils/metric_writers/tf/summary_writer_test.py
+++ b/src/jax_loop_utils/metric_writers/tf/summary_writer_test.py
@@ -109,19 +109,6 @@ class SummaryWriterTest(tf.test.TestCase):
         self.logdir = self.get_temp_dir()
         self.writer = summary_writer.SummaryWriter(self.logdir)
 
-    def test_write_summaries(self):
-        self.writer.write_summaries(
-            11,
-            {"a": np.eye(3, dtype=np.uint8), "b": np.eye(2, dtype=np.float32)},
-            {"a": np.ones((2, 3)).tobytes()},
-        )
-        self.writer.flush()
-        data, metadata = _load_summaries_data(self.logdir)
-        self.assertAllClose(
-            data[11], {"a": np.eye(3, dtype=np.uint8), "b": np.eye(2, dtype=np.float32)}
-        )
-        self.assertIn("a", metadata[11])
-
     def test_write_scalar(self):
         self.writer.write_scalars(11, {"a": 0.6, "b": 15})
         self.writer.write_scalars(20, {"a": 0.8, "b": 12})
@@ -166,24 +153,6 @@ class SummaryWriterTest(tf.test.TestCase):
             [(0.0, 0.35, 4), (0.35, 0.7, 1)],
         ]
         self.assertAllClose(data["b"], ([0, 2], expected_histograms_b))
-
-    def test_write_pointcloud(self):
-        point_clouds = np.random.normal(0, 1, (1, 1024, 3)).astype(np.float32)
-        point_colors = np.random.uniform(0, 1, (1, 1024, 3)).astype(np.float32)
-        config = {
-            "material": "PointCloudMaterial",
-            "size": 0.09,
-        }
-        self.writer.write_pointcloud(
-            step=0,
-            point_clouds={"pcd": point_clouds},
-            point_colors={"pcd": point_colors},
-            configs=config,
-        )
-        self.writer.flush()
-        data = _load_pointcloud_data(self.logdir)
-        self.assertAllClose(data[0]["pcd_VERTEX"], point_clouds)
-        self.assertAllClose(data[0]["pcd_COLOR"], point_colors)
 
     def test_hparams(self):
         self.writer.write_hparams(dict(batch_size=512, num_epochs=90))

--- a/src/jax_loop_utils/metric_writers/torch/tensorboard_writer.py
+++ b/src/jax_loop_utils/metric_writers/torch/tensorboard_writer.py
@@ -37,18 +37,6 @@ class TensorboardWriter(interface.MetricWriter):
         super().__init__()
         self._writer = SummaryWriter(log_dir=logdir)
 
-    def write_summaries(
-        self,
-        step: int,
-        values: Mapping[str, Array],
-        metadata: Optional[Mapping[str, Any]] = None,
-    ):
-        logging.log_first_n(
-            logging.WARNING,
-            "TorchTensorboardWriter does not support writing raw summaries.",
-            1,
-        )
-
     def write_scalars(self, step: int, scalars: Mapping[str, Scalar]):
         for key, value in scalars.items():
             self._writer.add_scalar(key, value, global_step=step)
@@ -86,20 +74,6 @@ class TensorboardWriter(interface.MetricWriter):
             self._writer.add_histogram(
                 tag, values, global_step=step, bins="auto", max_bins=bins
             )
-
-    def write_pointcloud(
-        self,
-        step: int,
-        point_clouds: Mapping[str, Array],
-        *,
-        point_colors: Mapping[str, Array] | None = None,
-        configs: Mapping[str, str | float | bool | None] | None = None,
-    ):
-        logging.log_first_n(
-            logging.WARNING,
-            "TorchTensorBoardWriter does not support writing point clouds.",
-            1,
-        )
 
     def write_hparams(self, hparams: Mapping[str, Any]):
         self._writer.add_hparams(hparams, {})

--- a/src/jax_loop_utils/metric_writers/utils.py
+++ b/src/jax_loop_utils/metric_writers/utils.py
@@ -24,13 +24,12 @@ method of the writer depending on the type of the metric.
 import collections
 from typing import Any, Mapping, Union
 
-from absl import flags
-from jax_loop_utils import values
-from jax_loop_utils.metric_writers.interface import MetricWriter
-
 import jax.numpy as jnp
 import numpy as np
+from absl import flags
 
+from jax_loop_utils import values
+from jax_loop_utils.metric_writers.interface import MetricWriter
 
 FLAGS = flags.FLAGS
 
@@ -62,11 +61,7 @@ def write_values(
     writes = collections.defaultdict(dict)
     histogram_num_buckets = collections.defaultdict(int)
     for k, v in metrics.items():
-        if isinstance(v, values.Summary):
-            writes[
-                (writer.write_summaries, frozenset({"metadata": v.metadata}.items()))
-            ][k] = v.value
-        elif _is_scalar(v):
+        if _is_scalar(v):
             if isinstance(v, values.Scalar):
                 writes[(writer.write_scalars, frozenset())][k] = v.value
             else:

--- a/src/jax_loop_utils/values.py
+++ b/src/jax_loop_utils/values.py
@@ -18,7 +18,7 @@ A Metric should return one of the following types when compute() is called.
 """
 
 import dataclasses
-from typing import Any, Union, Protocol, runtime_checkable
+from typing import Any, Protocol, Union, runtime_checkable
 
 import jax.numpy as jnp
 import numpy as np
@@ -36,12 +36,6 @@ class Value(Protocol):
     """
 
     value: Any
-
-
-@dataclasses.dataclass
-class Summary(Value):
-    value: ArrayType
-    metadata: Any
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
delete metric_writer.write_{pointcloud,summaries}

It was only really impelemented by the TF writer and it doesn't seem
that useful.

Change-Id: I14145dd1c7f2dafd7469593e31d7c9ab5108c77b