### PR TITLE
mlflow fixes

### DIFF
--- a/src/jax_loop_utils/metric_writers/mlflow/metric_writer.py
+++ b/src/jax_loop_utils/metric_writers/mlflow/metric_writer.py
@@ -8,6 +8,7 @@ import mlflow
 import mlflow.config
 import mlflow.entities
 import mlflow.tracking.fluent
+import numpy as np
 from absl import logging
 
 from jax_loop_utils.metric_writers.interface import (
@@ -64,7 +65,11 @@ class MlflowMetricWriter(MetricWriterInterface):
         """Write images to MLflow."""
         for key, image_array in images.items():
             self._client.log_image(
-                self._run_id, image_array, key=key, step=step, synchronous=False
+                self._run_id,
+                np.array(image_array),
+                key=key,
+                step=step,
+                synchronous=False,
             )
 
     def write_videos(self, step: int, videos: Mapping[str, Array]):

--- a/src/jax_loop_utils/metric_writers/mlflow/metric_writer.py
+++ b/src/jax_loop_utils/metric_writers/mlflow/metric_writer.py
@@ -122,9 +122,13 @@ class MlflowMetricWriter(MetricWriterInterface):
 
     def flush(self):
         """Flushes all logged data."""
-        mlflow.flush_artifact_async_logging()
-        mlflow.flush_async_logging()
-        mlflow.flush_trace_async_logging()
+        # using private APIs because the public APIs require global state
+        # for the current tracking URI and Run ID, and we don't want to
+        # create a global state.
+        artifact_repo = mlflow.tracking._get_artifact_repo(self._run_id)
+        if artifact_repo:
+            artifact_repo.flush_async_logging()
+        self._client._tracking_client.store.flush_async_logging()
 
     def close(self):
         """End the MLflow run."""

--- a/src/jax_loop_utils/metric_writers/mlflow/metric_writer_test.py
+++ b/src/jax_loop_utils/metric_writers/mlflow/metric_writer_test.py
@@ -4,6 +4,7 @@ import time
 import mlflow
 import mlflow.entities
 import numpy as np
+import jax.numpy as jnp
 from absl.testing import absltest
 
 from jax_loop_utils.metric_writers.mlflow import MlflowMetricWriter
@@ -58,7 +59,7 @@ class MlflowMetricWriterTest(absltest.TestCase):
             tracking_uri = f"file://{temp_dir}"
             experiment_name = "experiment_name"
             writer = MlflowMetricWriter(experiment_name, tracking_uri=tracking_uri)
-            writer.write_images(0, {"test_image": np.zeros((3, 3, 3), dtype=np.uint8)})
+            writer.write_images(0, {"test_image": jnp.zeros((3, 3, 3), dtype=np.uint8)})
             writer.close()
 
             runs = _get_runs(tracking_uri, experiment_name)

--- a/src/jax_loop_utils/metric_writers/torch/tensorboard_writer.py
+++ b/src/jax_loop_utils/metric_writers/torch/tensorboard_writer.py
@@ -39,7 +39,7 @@ class TensorboardWriter(interface.MetricWriter):
 
     def write_scalars(self, step: int, scalars: Mapping[str, Scalar]):
         for key, value in scalars.items():
-            self._writer.add_scalar(key, value, global_step=step)
+            self._writer.add_scalar(key, value, global_step=step, new_style=True)
 
     def write_images(self, step: int, images: Mapping[str, Array]):
         for key, value in images.items():

--- a/src/jax_loop_utils/metric_writers/torch/tensorboard_writer_test.py
+++ b/src/jax_loop_utils/metric_writers/torch/tensorboard_writer_test.py
@@ -18,9 +18,10 @@ import collections
 import os
 from typing import Any, Dict
 
-from jax_loop_utils.metric_writers.torch import tensorboard_writer
 import numpy as np
 import tensorflow as tf
+
+from jax_loop_utils.metric_writers.torch import tensorboard_writer
 
 
 def _load_scalars_data(logdir: str):
@@ -30,7 +31,9 @@ def _load_scalars_data(logdir: str):
     for path in paths:
         for event in tf.compat.v1.train.summary_iterator(path):
             for value in event.summary.value:
-                data[event.step][value.tag] = value.simple_value
+                assert value.HasField("tensor")
+                assert len(value.tensor.float_val) == 1
+                data[event.step][value.tag] = value.tensor.float_val[0]
 
     return data
 


### PR DESCRIPTION
convert images to numpy format. Input may be  a jax array, which MLFlow doesn't support.

fix flushing:
previously we were flushing on the default tracking URI, which is
$CWD/mlruns, disregarding the tracking URI that was set in the metric
writer constructor.

Change-Id: I80c93def5c776bccfbfac08387ca60662f9da335